### PR TITLE
Fix launch args build bug & Update README

### DIFF
--- a/GBCLV3/Properties/AssemblyInfo.cs
+++ b/GBCLV3/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright © Goose Bomb 2019")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("3.0.1.27")]
-[assembly: AssemblyFileVersion("3.0.1.27")]
+[assembly: AssemblyVersion("3.0.1.30")]
+[assembly: AssemblyFileVersion("3.0.1.30")]
 
 [assembly: ComVisible(false)]
 

--- a/GBCLV3/Services/Launcher/LaunchService.cs
+++ b/GBCLV3/Services/Launcher/LaunchService.cs
@@ -125,7 +125,7 @@ namespace GBCLV3.Services.Launcher
             builder.Append($"-Dminecraft.launcher.version={AssemblyUtil.Version} ");
 
             // Libraries
-            builder.Append("-cp ");
+            builder.Append("-cp \"");
             foreach (var lib in version.Libraries)
             {
                 if (lib.Type == LibraryType.Native) continue;
@@ -133,7 +133,7 @@ namespace GBCLV3.Services.Launcher
             }
 
             // Main Jar
-            builder.Append($"{_gamePathService.VersionsDir}/{version.JarID}/{version.JarID}.jar ");
+            builder.Append($"{_gamePathService.VersionsDir}/{version.JarID}/{version.JarID}.jar\" ");
 
             // Main Class
             builder.Append(version.MainClass).Append(' ');

--- a/README-CN.md
+++ b/README-CN.md
@@ -1,7 +1,30 @@
-# <img src="./GBCLV3/enderman.ico" width="32" height="32"/> GBCLV3
-![Platform: Win64](https://img.shields.io/badge/platform-win--64-lightgrey) ![.NET Framework: 4.7.2](https://img.shields.io/badge/.NET%20Framework-%3E%3D4.7.2-blue) [![License: MIT](https://img.shields.io/badge/License-MIT-green)](./LICENSE) 
-
-鹅弹的Minecraft客户端启动器 V3
+<p align="center">
+  <a>
+    <img src="./GBCLV3/enderman.ico" alt="Icon" width=64 height=64>
+  </a>
+  <h2 align="center">GBCLV3</h2>
+  <p align="center">
+    <a href="https://github.com/Goose-Bomb/GBCLV3/blob/master/LICENSE">
+      <img src="https://img.shields.io/github/license/Goose-Bomb/GBCLV3.svg" alt="License" />
+    </a>
+    <a>
+      <img src="https://img.shields.io/badge/platform-win--64-lightgrey.svg" alt="Platform">
+    </a>
+        <a>
+      <img src="https://img.shields.io/badge/.NET%20Framework-%3E%3D4.7.2-blueviolet.svg" alt=".NET Version">
+    </a>
+    <a href="https://github.com/Goose-Bomb/GBCLV3/archive/master.zip">
+      <img src="https://img.shields.io/github/languages/code-size/Goose-Bomb/GBCLV3.svg" alt="Code Size" />
+    </a>
+    <a href="https://github.com/Goose-Bomb/GBCLV3/releases">
+      <img src="https://img.shields.io/github/release/Goose-Bomb/GBCLV3/all.svg" alt="Last Release">
+          <a href="https://github.com/Goose-Bomb/GBCLV3/releases">
+      <img src="https://img.shields.io/github/downloads/Goose-Bomb/GBCLV3/total.svg" alt="All Downloads" />
+    </a>
+    </a>
+  </p>
+  <p align="center">鹅弹的Minecraft客户端启动器 V3</p>
+</p>
 
 ## 特点
 
@@ -42,6 +65,8 @@
   - [x] 模组管理
   - [x] 资源包管理
   - [ ] 存档管理
+
+- [ ] 自动升级
 
 ## 运行截图
 <img src="./Screenshots/cover_0.png" width="720"/>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,31 @@
-# <img src="./GBCLV3/enderman.ico" width="32" height="32"/> GBCLV3
-![Platform: Win64](https://img.shields.io/badge/platform-win--64-lightgrey) ![.NET Framework: 4.7.2](https://img.shields.io/badge/.NET%20Framework-%3E%3D4.7.2-blue) [![License: MIT](https://img.shields.io/badge/License-MIT-green)](./LICENSE) 
+<p align="center">
+  <a>
+    <img src="./GBCLV3/enderman.ico" alt="Icon" width=64 height=64>
+  </a>
+  <h2 align="center">GBCLV3</h2>
+  <p align="center">
+    <a href="https://github.com/Goose-Bomb/GBCLV3/blob/master/LICENSE">
+      <img src="https://img.shields.io/github/license/Goose-Bomb/GBCLV3.svg" alt="License" />
+    </a>
+    <a>
+      <img src="https://img.shields.io/badge/platform-win--64-lightgrey.svg" alt="Platform">
+    </a>
+        <a>
+      <img src="https://img.shields.io/badge/.NET%20Framework-%3E%3D4.7.2-blueviolet.svg" alt=".NET Version">
+    </a>
+    <a href="https://github.com/Goose-Bomb/GBCLV3/archive/master.zip">
+      <img src="https://img.shields.io/github/languages/code-size/Goose-Bomb/GBCLV3.svg" alt="Code Size" />
+    </a>
+    <a href="https://github.com/Goose-Bomb/GBCLV3/releases">
+      <img src="https://img.shields.io/github/release/Goose-Bomb/GBCLV3/all.svg" alt="Last Release">
+          <a href="https://github.com/Goose-Bomb/GBCLV3/releases">
+      <img src="https://img.shields.io/github/downloads/Goose-Bomb/GBCLV3/total.svg" alt="All Downloads" />
+    </a>
+    </a>
+  </p>
+  <p align="center">Goose Bomb's Minecraft Client Launcher V3</p>
+</p>
 
-Goose Bomb's Minecraft Client Launcher V3
 [简体中文](./README-CN.md)
 
 ## Features
@@ -43,6 +67,8 @@ Goose Bomb's Minecraft Client Launcher V3
   - [x] Mods management
   - [x] Resourcepacks management
   - [ ] Saves management
+
+- [ ] Auto update
 
 ## Screenshots
 


### PR DESCRIPTION
- Add double quotes around libraries paths in launch arguments, which can ensure some bizarre version with name that contains white space (e.g, the ridiculous "3D Shareware v1.3.4") to successfully launch
- Make README looks prettier