### PR TITLE
Add copy mods option & Support fabric mod information loading

### DIFF
--- a/GBCLV3/Models/Auxiliary/Mod.cs
+++ b/GBCLV3/Models/Auxiliary/Mod.cs
@@ -6,8 +6,7 @@
 
         public string FileName { get; set; }
 
-        public string DisplayName => !string.IsNullOrWhiteSpace(Description) ? 
-                                        $"{Description}\nby {Authors}" : null;
+        public string DisplayName { get; set; }
 
         public string Description { get; set; }
 
@@ -26,9 +25,9 @@
 
     #region Json Class
 
-    public class JMod
+    public class ForgeMod
     {
-        public JMod[] modList { get; set; }
+        public ForgeMod[] modList { get; set; }
 
         public string name { get; set; }
 
@@ -43,6 +42,30 @@
         public string[] authorList { get; set; }
 
         public string url { get; set; }
+    }
+
+    class FabricModContact
+    {
+        public string homepage { get; set; }
+
+        public string sources { get; set; }
+    }
+
+    class FabricMod
+    {
+        public int schemaVersion { get; set; }
+
+        public string id { get; set; }
+
+        public string version { get; set; }
+
+        public string name { get; set; }
+
+        public string description { get; set; }
+
+        public string[] authors { get; set; }
+
+        public FabricModContact contact { get; set; }
     }
 
     #endregion

--- a/GBCLV3/Models/Config.cs
+++ b/GBCLV3/Models/Config.cs
@@ -70,7 +70,7 @@ namespace GBCLV3.Models
 
         public bool DownloadAssetsOnInstall { get; set; }
 
-        public bool CopyPacks { get; set; }
+        public bool CopyMods { get; set; }
 
         #endregion
     }

--- a/GBCLV3/Resources/Languages/EN-US.xaml
+++ b/GBCLV3/Resources/Languages/EN-US.xaml
@@ -209,6 +209,8 @@
     <s:String x:Key="SelectMods">Select Mods</s:String>
     <s:String x:Key="EnableSelected">Enable</s:String>
     <s:String x:Key="DisableSelected">Disable</s:String>
+    <s:String x:Key="CopyMods">When add new mods, copy instead of moving them from source directory</s:String>
+
 
     <!-- Resourcepacks Management -->
     <s:String x:Key="EnabledPacks">Enabled Packs</s:String>

--- a/GBCLV3/Resources/Languages/ZH-CN.xaml
+++ b/GBCLV3/Resources/Languages/ZH-CN.xaml
@@ -210,6 +210,7 @@
     <s:String x:Key="SelectMods">请选择模组</s:String>
     <s:String x:Key="EnableSelected">启用选中</s:String>
     <s:String x:Key="DisableSelected">禁用选中</s:String>
+    <s:String x:Key="CopyMods">添加新模组时，仅复制并保留原位置的模组文件</s:String>
 
     <!-- 资源包管理 -->
     <s:String x:Key="EnabledPacks">启用的资源包</s:String>

--- a/GBCLV3/Resources/Languages/de-DE.xaml
+++ b/GBCLV3/Resources/Languages/de-DE.xaml
@@ -209,6 +209,8 @@
     <s:String x:Key="SelectMods">Mods auswählen</s:String>
     <s:String x:Key="EnableSelected">Aktivieren</s:String>
     <s:String x:Key="DisableSelected">Deaktivieren</s:String>
+    <!-- TRANSLATION NEEDED HERE -->
+    <s:String x:Key="CopyMods">When add new mods, copy instead of moving them from source directory</s:String>
 
     <!-- Resourcepacks-Verwaltung -->
     <s:String x:Key="EnabledPacks">Aktivierte Packs</s:String>

--- a/GBCLV3/Resources/Languages/ru-RU.xaml
+++ b/GBCLV3/Resources/Languages/ru-RU.xaml
@@ -209,6 +209,9 @@
     <s:String x:Key="SelectMods">Выбор модов</s:String>
     <s:String x:Key="EnableSelected">Включить</s:String>
     <s:String x:Key="DisableSelected">Выключить</s:String>
+    <!-- TRANSLATION NEEDED HERE -->
+    <s:String x:Key="CopyMods">When add new mods, copy instead of moving them from source directory</s:String>
+
 
     <!-- Управление пакетами ресурсов -->
     <s:String x:Key="EnabledPacks">Включенные пакеты</s:String>

--- a/GBCLV3/Resources/Languages/zh-TW.xaml
+++ b/GBCLV3/Resources/Languages/zh-TW.xaml
@@ -210,6 +210,7 @@
     <s:String x:Key="SelectMods">請選擇模組</s:String>
     <s:String x:Key="EnableSelected">啟用選中</s:String>
     <s:String x:Key="DisableSelected">禁用選中</s:String>
+    <s:String x:Key="CopyMods">添加新模組時從原位置複製而非移動</s:String>
 
     <!-- 資源包管理 -->
     <s:String x:Key="EnabledPacks">啟用的資源包</s:String>

--- a/GBCLV3/Views/Tabs/ModView.xaml
+++ b/GBCLV3/Views/Tabs/ModView.xaml
@@ -40,8 +40,33 @@
 
         </StackPanel>
 
-        <GroupBox Grid.Row="1" Grid.ColumnSpan="4" Margin="8"
-                  Header="{DynamicResource AvailableMods}">
+        <GroupBox Grid.Row="1" Grid.ColumnSpan="4" Margin="8">
+
+            <GroupBox.Header>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               VerticalAlignment="Center"
+                               Text="{DynamicResource AvailableMods}" />
+
+                    <ToggleButton Grid.Column="1"
+                            Style="{StaticResource {x:Static adonisUI:Styles.ToolbarToggleButton}}"
+                            HorizontalAlignment="Right"
+                            Width="32" Height="32"
+                            FontFamily="Segoe MDL2 Assets"
+                            FontSize="16"
+                            Content="&#xE8C8;"
+                            ToolTipService.Placement="Relative"
+                            ToolTipService.HorizontalOffset="-240"
+                            ToolTipService.VerticalOffset="32"
+                            ToolTip="{DynamicResource CopyMods}"
+                            IsChecked="{Binding IsCopyMods, Mode=TwoWay}"/>
+                </Grid>
+            </GroupBox.Header>
 
             <ListBox ItemsSource="{Binding Mods, Mode=OneWay}"
                      BorderThickness="1"
@@ -49,7 +74,7 @@
                      ScrollViewer.VerticalScrollBarVisibility="Auto"
                      ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                      SelectionChanged="{s:Action SelectionChanged}"
-                     Drop="{s:Action DropFiles}">
+                     Drop="{s:Action OnDropMods}">
 
                 <ListBox.ItemTemplate>
                     <DataTemplate>


### PR DESCRIPTION
Add an option to control whether move or copy mods files from source directory when installing new mods, as mentioned in #37.
Add fabric mod information loading (the _fabric.mod.json_)